### PR TITLE
ajouté la fonctionalitée backend du dashboard pour les astroflats de …

### DIFF
--- a/app/assets/stylesheets/components/_dashboard_flats_container.scss
+++ b/app/assets/stylesheets/components/_dashboard_flats_container.scss
@@ -1,0 +1,18 @@
+.dashboard-flats-container {
+  max-width: 540px;
+  background-color: white;
+  padding: 32px;
+  margin: 32px;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  border-radius: 4px;
+
+  article {
+    margin: 16px;
+  }
+
+  img {
+    width: 200px;
+  }
+}

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -10,3 +10,4 @@
 @import 'cardgrid';
 @import 'card';
 @import 'box_astroflat';
+@import 'dashboard_flats_container';

--- a/app/controllers/astroflats_controller.rb
+++ b/app/controllers/astroflats_controller.rb
@@ -5,6 +5,11 @@ class AstroflatsController < ApplicationController
     @astroflats = policy_scope(Astroflat)
   end
 
+  def dashboard
+    authorize Astroflat
+    @astroflats = Astroflat.where(user: current_user)
+  end
+
   def show
     authorize @astroflat
   end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -12,6 +12,10 @@ class ApplicationPolicy
     false
   end
 
+  def dashboard?
+    false
+  end
+
   def show?
     false
   end

--- a/app/policies/astroflat_policy.rb
+++ b/app/policies/astroflat_policy.rb
@@ -6,6 +6,10 @@ class AstroflatPolicy < ApplicationPolicy
     end
   end
 
+  def dashboard?
+    true
+  end
+
   def show?
     true
   end

--- a/app/views/astroflats/dashboard.html.erb
+++ b/app/views/astroflats/dashboard.html.erb
@@ -1,0 +1,11 @@
+<section>
+  <h2>Astro dashboard</h2>
+  <div class="dashboard-flats-container">
+    <% @astroflats.each do |item| %>
+      <article>
+        <p><%= item.flat_name %></p>
+        <%= item.photo.attached? ? cl_image_tag(item.photo.key) : image_tag("planet.jpg") %>
+      </article>
+    <% end %>
+  </div>
+</section>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -16,7 +16,7 @@
             <li class="nav-item dropdown">
               <%= image_tag "https://cdn-icons-png.flaticon.com/128/547/547420.png", class: "avatar dropdown-toggle", id: "navbarDropdown", data: { bs_toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
               <div class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">
-                <%= link_to "My astroflat", astroflats_path, class: "dropdown-item" %>
+                <%= link_to "astro dashboard", dashboard_path, class: "dropdown-item" %>
                 <%= link_to "Add astroflat", new_astroflat_path, class: "dropdown-item" %>
                 <%= link_to "Log out", destroy_user_session_path, class: "dropdown-item", data: {turbo_method: :delete} %>
               </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,5 +9,8 @@ Rails.application.routes.draw do
   resources :astroflats do
     resources :bookings, only: %i[new create]
   end
+  # dashboard route
+  get 'dashboard', to: 'astroflats#dashboard'
+
   resources :bookings, only: [:show, :destroy]
 end


### PR DESCRIPTION
…l'utilisateur

<img width="252" alt="image" src="https://user-images.githubusercontent.com/74938003/203650021-ef89ac04-4c07-4149-ab6b-fd9c9aae0569.png">

utlisateur peut clicker sur dashboard
cela amene sur une nouvelle view qui ne montre uniquement les astroflats qu'il ou elle a créé.
Il y aura à faire: ajouter les bookings par astroflat dont l'utilisateur est propriétaire. Et une autre partie sur la dashboard qui montre les bookings dont l'utilisateur n'est pas le proprietaire (le locataire/vacancier...)

<img width="937" alt="image" src="https://user-images.githubusercontent.com/74938003/203650233-6159b635-3bdc-4911-973e-bcea425d565b.png">


