### PR TITLE
mini modif de style dashboard bg et btn création bookin dans astro show

### DIFF
--- a/app/assets/stylesheets/components/_box_astroflat.scss
+++ b/app/assets/stylesheets/components/_box_astroflat.scss
@@ -1,7 +1,7 @@
 .box-astroflat {
   display: flex;
   flex-direction: row;
-  justify-content: center;
+  justify-content: space-around;
   align-items: center;
   margin: 25px auto 0 auto;
   border-radius: 20px;
@@ -11,6 +11,10 @@
   .flat-details {
     max-width: 500px;
     margin: 1rem;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+
   }
   img {
     width: 450px;

--- a/app/assets/stylesheets/components/_button.scss
+++ b/app/assets/stylesheets/components/_button.scss
@@ -3,7 +3,7 @@
   padding: 8px 24px;
   border-radius: 4px;
   background: #f59972;
-  transition: background 0.3s ease;
+  transition: all 0.3s ease-in-out;
 }
 
 .btn-flat-violet {
@@ -11,7 +11,14 @@
   padding: 8px 24px;
   border-radius: 4px;
   background: #B01E68;
-  transition: background 0.3s ease;
+  transition: all 0.3s ease-in-out;
+  margin: 0 auto;
+  &:hover {
+    background: rgb(234, 234, 234);
+    a {
+      color: black;
+    }
+  }
 }
 
 // .btn-small {

--- a/app/assets/stylesheets/components/_dashboard_flats_container.scss
+++ b/app/assets/stylesheets/components/_dashboard_flats_container.scss
@@ -1,7 +1,8 @@
 .dashboard-flats-container {
   max-width: 540px;
   height: fit-content;
-  background-color: white;
+  background-image: linear-gradient(rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0.8)),
+                    url('https://cdn.pixabay.com/photo/2017/12/28/12/31/sketch-3045125_1280.jpg');
   padding: 32px;
   margin: 32px;
   display: flex;
@@ -10,7 +11,7 @@
   flex-wrap: wrap;
   border-radius: 4px;
   .dash-info-card {
-    background-color: rgba(255, 225, 93, 0.5);
+    background-color: rgb(255, 237, 155);
     h4 {
       font-weight: bolder;
     }
@@ -18,6 +19,7 @@
   a {
     color: black;
     article {
+      background-color: white;
       margin: 16px;
       width: 200px;
       height: 270px;

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -16,7 +16,7 @@
             <li class="nav-item dropdown">
               <%= image_tag "https://cdn-icons-png.flaticon.com/128/547/547420.png", class: "avatar dropdown-toggle", id: "navbarDropdown", data: { bs_toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
               <div class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">
-                <%= link_to "astro dashboard", dashboard_path, class: "dropdown-item" %>
+                <%= link_to "Astro dashboard", dashboard_path, class: "dropdown-item" %>
                 <%= link_to "Add astroflat", new_astroflat_path, class: "dropdown-item" %>
                 <%= link_to "Log out", destroy_user_session_path, class: "dropdown-item", data: {turbo_method: :delete} %>
               </div>


### PR DESCRIPTION
centré le btn dans la show de astroflat. hover est rectifié aussi.
<img width="869" alt="image" src="https://user-images.githubusercontent.com/74938003/203787557-8a0753f6-b62f-46c0-a8a0-59320aa1a4d8.png">

ajout d'un bg un peu stylisé pour la dash :

<img width="455" alt="image" src="https://user-images.githubusercontent.com/74938003/203787875-f8624da5-e4fb-44ad-8011-83dc61eeaa87.png">
 

@FranckL93 @embarthe51 @ElodieBou97  Il ya plusieurs btns qui ont des styles hover ... invisible. C'est facile à rectifier en SCSS/CSS. Je peux vous montrer comment faire ça rapidement demain ou la semaine prochaine si vous voulez.   
